### PR TITLE
Implement simple audio playback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.exoplayer)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -10,7 +12,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.MusicPlayAndroidAI">
+        android:theme="@style/Theme.MusicPlayAndroidAI"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/musicplayandroidai/MainActivity.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/MainActivity.kt
@@ -1,47 +1,94 @@
 package com.example.musicplayandroidai
 
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.musicplayandroidai.player.PlayerManager
+import com.example.musicplayandroidai.player.rememberFilePicker
 import com.example.musicplayandroidai.ui.theme.MusicPlayAndroidAITheme
 
 class MainActivity : ComponentActivity() {
+    private lateinit var playerManager: PlayerManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        playerManager = PlayerManager(applicationContext)
         setContent {
             MusicPlayAndroidAITheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                MusicPlayerScreen(playerManager)
             }
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        playerManager.release()
+    }
+}
+
+@Composable
+fun MusicPlayerScreen(playerManager: PlayerManager) {
+    var selectedUri by remember { mutableStateOf<Uri?>(null) }
+    var fileName by remember { mutableStateOf<String?>(null) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val filePicker = rememberFilePicker { uri ->
+        selectedUri = uri
+        fileName = uri?.lastPathSegment
+        uri?.let { playerManager.prepare(it) }
+    }
+
+    errorMessage?.let { message ->
+        LaunchedEffect(message) {
+            snackbarHostState.showSnackbar(message)
+            errorMessage = null
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(text = "Musicplay")
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(onClick = { filePicker.pickAudio() }) {
+                Text("Выбрать аудиофайл")
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = {
+                    if (selectedUri != null) {
+                        playerManager.play()
+                    } else {
+                        errorMessage = "Файл не выбран"
+                    }
+                }) { Text("Play") }
+                Button(onClick = { playerManager.pause() }) { Text("Pause") }
+                Button(onClick = { playerManager.stop() }) { Text("Stop") }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(text = fileName ?: "Файл не выбран")
         }
     }
 }
 
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    MusicPlayAndroidAITheme {
-        Greeting("Android")
-    }
-}

--- a/app/src/main/java/com/example/musicplayandroidai/player/FilePicker.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/player/FilePicker.kt
@@ -1,0 +1,28 @@
+package com.example.musicplayandroidai.player
+
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+class FilePicker(private val launcher: ActivityResultLauncher<Array<String>>) {
+    fun pickAudio() {
+        launcher.launch(arrayOf("audio/*"))
+    }
+}
+
+@Composable
+fun rememberFilePicker(onFilePicked: (Uri?) -> Unit): FilePicker {
+    val activity = LocalContext.current as ComponentActivity
+    val launcher = remember(activity) {
+        activity.registerForActivityResult(ActivityResultContracts.OpenDocument(), onFilePicked)
+    }
+    DisposableEffect(Unit) {
+        onDispose { launcher.unregister() }
+    }
+    return remember { FilePicker(launcher) }
+}

--- a/app/src/main/java/com/example/musicplayandroidai/player/PlayerManager.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/player/PlayerManager.kt
@@ -1,0 +1,25 @@
+package com.example.musicplayandroidai.player
+
+import android.content.Context
+import android.net.Uri
+import com.google.android.exoplayer2.ExoPlayer
+import com.google.android.exoplayer2.MediaItem
+
+class PlayerManager(context: Context) {
+    private val player: ExoPlayer = ExoPlayer.Builder(context.applicationContext).build()
+
+    fun prepare(uri: Uri) {
+        val mediaItem = MediaItem.fromUri(uri)
+        player.setMediaItem(mediaItem)
+        player.prepare()
+    }
+
+    fun play() = player.play()
+
+    fun pause() = player.pause()
+
+    fun stop() = player.stop()
+
+    fun release() = player.release()
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+exoplayer = "2.19.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+exoplayer = { group = "com.google.android.exoplayer", name = "exoplayer", version.ref = "exoplayer" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add ExoPlayer dependency
- create PlayerManager wrapper
- implement file picker utility
- build simple Compose UI for playback controls
- request legacy storage permission

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884eb4173b8832d9f17356a4b91e0c1