### PR TITLE
Add simple logger for debugging

### DIFF
--- a/app/src/main/java/com/example/musicplayandroidai/AppLogger.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/AppLogger.kt
@@ -1,0 +1,10 @@
+object AppLogger {
+    private const val TAG = "MusicplayLog"
+
+    fun d(message: String) = android.util.Log.d(TAG, message)
+    fun i(message: String) = android.util.Log.i(TAG, message)
+    fun e(message: String, throwable: Throwable? = null) {
+        if (throwable != null) android.util.Log.e(TAG, message, throwable)
+        else android.util.Log.e(TAG, message)
+    }
+}

--- a/app/src/main/java/com/example/musicplayandroidai/MainActivity.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/MainActivity.kt
@@ -18,12 +18,14 @@ import androidx.compose.ui.unit.dp
 import com.example.musicplayandroidai.player.PlayerManager
 import com.example.musicplayandroidai.player.rememberFilePicker
 import com.example.musicplayandroidai.ui.theme.MusicPlayAndroidAITheme
+import com.example.musicplayandroidai.AppLogger
 
 class MainActivity : ComponentActivity() {
     private lateinit var playerManager: PlayerManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        AppLogger.d("App started")
         enableEdgeToEdge()
         playerManager = PlayerManager(applicationContext)
         setContent {
@@ -71,20 +73,31 @@ fun MusicPlayerScreen(playerManager: PlayerManager) {
         ) {
             Text(text = "Musicplay")
             Spacer(modifier = Modifier.height(16.dp))
-            Button(onClick = { filePicker.pickAudio() }) {
+            Button(onClick = {
+                AppLogger.d("Select file button clicked")
+                filePicker.pickAudio()
+            }) {
                 Text("Выбрать аудиофайл")
             }
             Spacer(modifier = Modifier.height(16.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 Button(onClick = {
+                    AppLogger.d("Play clicked")
                     if (selectedUri != null) {
                         playerManager.play()
                     } else {
                         errorMessage = "Файл не выбран"
+                        AppLogger.e("Playback error: file not selected")
                     }
                 }) { Text("Play") }
-                Button(onClick = { playerManager.pause() }) { Text("Pause") }
-                Button(onClick = { playerManager.stop() }) { Text("Stop") }
+                Button(onClick = {
+                    AppLogger.d("Pause clicked")
+                    playerManager.pause()
+                }) { Text("Pause") }
+                Button(onClick = {
+                    AppLogger.d("Stop clicked")
+                    playerManager.stop()
+                }) { Text("Stop") }
             }
             Spacer(modifier = Modifier.height(16.dp))
             Text(text = fileName ?: "Файл не выбран")

--- a/app/src/main/java/com/example/musicplayandroidai/player/FilePicker.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/player/FilePicker.kt
@@ -5,11 +5,13 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import com.example.musicplayandroidai.AppLogger
 
 class FilePicker(
     private val launcher: androidx.activity.result.ActivityResultLauncher<Array<String>>
 ) {
     fun pickAudio() {
+        AppLogger.d("Select file button clicked")
         // Launch the system file picker requesting audio files
         launcher.launch(arrayOf("audio/*"))
     }
@@ -20,7 +22,14 @@ fun rememberFilePicker(onFilePicked: (Uri?) -> Unit): FilePicker {
     // Create a launcher that survives recomposition and is registered at the correct lifecycle state
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument(),
-        onResult = onFilePicked
+        onResult = { uri ->
+            if (uri != null) {
+                AppLogger.d("File selected: $uri")
+            } else {
+                AppLogger.e("File selection failed")
+            }
+            onFilePicked(uri)
+        }
     )
     // Provide a stable FilePicker instance
     return remember { FilePicker(launcher) }

--- a/app/src/main/java/com/example/musicplayandroidai/player/PlayerManager.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/player/PlayerManager.kt
@@ -2,24 +2,58 @@ package com.example.musicplayandroidai.player
 
 import android.content.Context
 import android.net.Uri
+import com.example.musicplayandroidai.AppLogger
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 
 class PlayerManager(context: Context) {
     private val player: ExoPlayer = ExoPlayer.Builder(context.applicationContext).build()
 
-    fun prepare(uri: Uri) {
-        val mediaItem = MediaItem.fromUri(uri)
-        player.setMediaItem(mediaItem)
-        player.prepare()
+    init {
+        AppLogger.d("Player initialized")
     }
 
-    fun play() = player.play()
+    fun prepare(uri: Uri) {
+        try {
+            val mediaItem = MediaItem.fromUri(uri)
+            player.setMediaItem(mediaItem)
+            player.prepare()
+            AppLogger.d("Player prepared with uri: $uri")
+        } catch (e: Exception) {
+            AppLogger.e("Error preparing player", e)
+        }
+    }
 
-    fun pause() = player.pause()
+    fun play() {
+        try {
+            player.play()
+            AppLogger.d("Playing audio")
+        } catch (e: Exception) {
+            AppLogger.e("Error during playback", e)
+        }
+    }
 
-    fun stop() = player.stop()
+    fun pause() {
+        try {
+            player.pause()
+            AppLogger.d("Paused audio")
+        } catch (e: Exception) {
+            AppLogger.e("Error pausing playback", e)
+        }
+    }
 
-    fun release() = player.release()
+    fun stop() {
+        try {
+            player.stop()
+            AppLogger.d("Stopped audio")
+        } catch (e: Exception) {
+            AppLogger.e("Error stopping playback", e)
+        }
+    }
+
+    fun release() {
+        player.release()
+        AppLogger.d("Player released")
+    }
 }
 


### PR DESCRIPTION
## Summary
- provide a central `AppLogger` wrapper over `android.util.Log`
- hook logging into `PlayerManager` for player lifecycle
- show log messages for UI actions in `MainActivity`
- log file picking flow in `FilePicker`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f37d8c84832d9e4c7f0203351496