### PR TITLE
Fix player release timing

### DIFF
--- a/app/src/main/java/com/example/musicplayandroidai/MainActivity.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/MainActivity.kt
@@ -37,6 +37,11 @@ class MainActivity : ComponentActivity() {
 
     override fun onStop() {
         super.onStop()
+        // Keep player instance when returning from file picker
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
         playerManager.release()
     }
 }


### PR DESCRIPTION
## Summary
- avoid releasing the ExoPlayer when the app goes to the background
- move `release()` to `onDestroy` so file picker won't break playback

## Testing
- `./gradlew lint test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850641c738832da69222aef7ee6944