### PR TITLE
Refine GlassDock inner layout to remove inner band

### DIFF
--- a/app/src/main/java/com/example/musicplayandroidai/ui/navigation/GlassDock.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/ui/navigation/GlassDock.kt
@@ -13,9 +13,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -185,7 +185,7 @@ private fun DockTab(
         if (isSelected) {
             Box(
                 modifier = Modifier
-                    .matchParentSize()
+                    .fillMaxSize()
                     .background(color = pillColor, shape = RoundedCornerShape(16.dp))
             )
         }

--- a/app/src/main/java/com/example/musicplayandroidai/ui/navigation/GlassDock.kt
+++ b/app/src/main/java/com/example/musicplayandroidai/ui/navigation/GlassDock.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -95,33 +96,37 @@ fun GlassDock(
                         .wrapContentWidth()
                 ) {
                     Box(modifier = Modifier.clip(dockShape)) {
-                        Row(
+                        Box(
                             modifier = Modifier
-                                .padding(horizontal = 12.dp, vertical = 10.dp)
-                                .height(56.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                .height(64.dp)
+                                .padding(horizontal = 12.dp),
+                            contentAlignment = Alignment.Center
                         ) {
-                            DockHandleButton(symbol = ">", onClick = onToggleExpanded, size = 48.dp)
-                            bottomBarDestinations.forEach { destination ->
-                                val isSelected = destination.route == currentRoute
-                                DockTab(
-                                    label = destination.label,
-                                    isSelected = isSelected,
-                                    activeColor = activeColor,
-                                    inactiveColor = inactiveColor,
-                                    onClick = {
-                                        if (currentRoute != destination.route) {
-                                            navController.navigate(destination.route) {
-                                                launchSingleTop = true
-                                                popUpTo(AppDestination.Library.route) { saveState = true }
-                                                restoreState = true
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                DockHandleButton(symbol = ">", onClick = onToggleExpanded, size = 48.dp)
+                                bottomBarDestinations.forEach { destination ->
+                                    val isSelected = destination.route == currentRoute
+                                    DockTab(
+                                        label = destination.label,
+                                        isSelected = isSelected,
+                                        activeColor = activeColor,
+                                        inactiveColor = inactiveColor,
+                                        onClick = {
+                                            if (currentRoute != destination.route) {
+                                                navController.navigate(destination.route) {
+                                                    launchSingleTop = true
+                                                    popUpTo(AppDestination.Library.route) { saveState = true }
+                                                    restoreState = true
+                                                }
                                             }
                                         }
-                                    }
-                                )
+                                    )
+                                }
+                                Spacer(modifier = Modifier.width(4.dp))
                             }
-                            Spacer(modifier = Modifier.width(4.dp))
                         }
                     }
                 }
@@ -167,16 +172,23 @@ private fun DockTab(
     inactiveColor: Color,
     onClick: () -> Unit
 ) {
-    val highlightColor = if (isSelected) activeColor.copy(alpha = 0.18f) else Color.Transparent
     val textColor = if (isSelected) activeColor.copy(alpha = 0.95f) else inactiveColor
+    val pillColor = activeColor.copy(alpha = 0.18f)
     Box(
         modifier = Modifier
-            .background(color = highlightColor, shape = RoundedCornerShape(16.dp))
+            .height(40.dp)
+            .clip(RoundedCornerShape(16.dp))
             .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .height(40.dp),
+            .padding(horizontal = 16.dp),
         contentAlignment = Alignment.Center
     ) {
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(color = pillColor, shape = RoundedCornerShape(16.dp))
+            )
+        }
         Text(
             text = label,
             color = textColor,


### PR DESCRIPTION
### Motivation
- Remove the visual "inner gray band" inside the glass capsule so the dock preview matches the device appearance and no secondary background is drawn inside the capsule.
- Ensure only the outer glass capsule (shape + border + shadow + alpha) provides the dock background while inner tab containers remain transparent.
- Make the active tab indicator (pill) a self-drawn, clipped layer that does not create an extra background strip.

### Description
- Replace the direct padded `Row` inside the `Surface` with a centered `Box` (`.height(64.dp)` + `contentAlignment = Alignment.Center`) and place the `Row` inside it so the inner content is vertically centered without its own background. The change is in `GlassDock` around the expanded layout area (`Box`/`Row` replacement).
- Update `DockTab` to remove the previous `.background(...)` usage and instead `clip` the tab shape, set a fixed height, and draw the active pill as a separate `Box` using `.matchParentSize()` when `isSelected` is true; the pill uses `activeColor.copy(alpha = 0.18f)` so it is constrained by the tab clipping.
- Add `matchParentSize` import and minor padding adjustments to keep tab layout consistent while preventing additional underlays.
- Preserve navigation behavior and `expanded`/`collapsed` logic; no navigation or state flow changes were made.

### Testing
- No automated tests were run because this is a UI-only visual adjustment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a33d28d0832d8ddc6187096581c8)